### PR TITLE
General styling improvements

### DIFF
--- a/assets/styles.qss
+++ b/assets/styles.qss
@@ -83,3 +83,7 @@ QToolButton#btnToggle {
     border: none;
     font-size: 14pt;
 }
+
+QScrollBar {
+    width: 14px;
+}

--- a/assets/styles.qss
+++ b/assets/styles.qss
@@ -35,7 +35,7 @@ QHeaderView::section {
     border: 1px solid #6c6c6c;
 }
 
-QLabel#lblPageName, QLabel#lblHeader, #btnOpenFile, #btnXlsxFile {
+QLabel#lblPageName, QLabel#lblHeader, #btnOpenFile {
     font-size: 17pt;
 }
 

--- a/assets/styles.qss
+++ b/assets/styles.qss
@@ -39,6 +39,10 @@ QLabel#lblPageName, QLabel#lblHeader, #btnOpenFile, #btnXlsxFile {
     font-size: 17pt;
 }
 
+QLabel#lblHeader {
+    font-weight: 500;
+}
+
 QLabel#lblHint {
     color: rgb(80,80,80);
 }

--- a/src/UI/AboutPage/aboutpage.ui
+++ b/src/UI/AboutPage/aboutpage.ui
@@ -6,20 +6,57 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>817</width>
+    <width>764</width>
     <height>467</height>
    </rect>
   </property>
-  <property name="windowTitle">
-   <string>Form</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QHBoxLayout" name="horizontalLayout_6">
    <property name="spacing">
     <number>15</number>
    </property>
+   <property name="leftMargin">
+    <number>11</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>11</number>
+   </property>
+   <property name="bottomMargin">
+    <number>11</number>
+   </property>
    <item>
-    <widget class="QWidget" name="wdProduct" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <spacer name="horizontalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QWidget" name="wdCenter" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>600</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>1000</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="spacing">
+       <number>20</number>
+      </property>
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -33,33 +70,8 @@
        <number>15</number>
       </property>
       <item>
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QWidget" name="wdIcon" native="true">
-        <property name="minimumSize">
-         <size>
-          <width>128</width>
-          <height>128</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>128</width>
-          <height>128</height>
-         </size>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout">
+       <widget class="QWidget" name="wdProduct" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -70,149 +82,36 @@
           <number>0</number>
          </property>
          <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="lblIcon">
-           <property name="text">
-            <string/>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="wdProductName" native="true">
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QWidget" name="filler1" native="true"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblName">
-           <property name="styleSheet">
-            <string notr="true">font-size: 20pt;</string>
-           </property>
-           <property name="text">
-            <string>Pretty name</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLabel" name="lblVersion">
-           <property name="styleSheet">
-            <string notr="true">font-size: 18pt;</string>
-           </property>
-           <property name="text">
-            <string>Version</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="filler2" native="true"/>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_4">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="grpContact">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>100</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>İletişim Bilgileri</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>370</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QWidget" name="contactCards" native="true">
-        <layout class="QHBoxLayout" name="horizontalLayout_3"/>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>369</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="grpLicense">
-     <property name="title">
-      <string>Lisans Bilgileri</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QWidget" name="innerLicense" native="true">
-        <layout class="QFormLayout" name="formLayout">
-         <property name="horizontalSpacing">
           <number>15</number>
          </property>
-         <property name="verticalSpacing">
-          <number>15</number>
-         </property>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label">
-           <property name="text">
-            <string>Lisans Durumu: </string>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
-          </widget>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
-         <item row="0" column="1">
-          <widget class="QWidget" name="widget" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="QWidget" name="wdIcon" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>128</width>
+             <height>128</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>128</width>
+             <height>128</height>
+            </size>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout">
             <property name="leftMargin">
              <number>0</number>
             </property>
@@ -226,63 +125,245 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QLabel" name="imgLicenseStatus">
-              <property name="minimumSize">
-               <size>
-                <width>22</width>
-                <height>22</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>22</width>
-                <height>22</height>
-               </size>
-              </property>
+             <widget class="QLabel" name="lblIcon">
               <property name="text">
                <string/>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="lblLicenseStatus">
-              <property name="text">
-               <string>Etkinleştirildi</string>
               </property>
              </widget>
             </item>
            </layout>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="lblSerial">
-           <property name="text">
-            <string>Lisans Anahtarı:</string>
-           </property>
+         <item>
+          <widget class="QWidget" name="wdProductName" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout">
+            <item>
+             <widget class="QWidget" name="filler1" native="true"/>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblName">
+              <property name="styleSheet">
+               <string notr="true">font-size: 20pt;</string>
+              </property>
+              <property name="text">
+               <string>Pretty name</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="lblVersion">
+              <property name="styleSheet">
+               <string notr="true">font-size: 18pt;</string>
+              </property>
+              <property name="text">
+               <string>Version</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QWidget" name="filler2" native="true"/>
+            </item>
+           </layout>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QLineEdit" name="txtSerial">
-           <property name="readOnly">
-            <bool>true</bool>
+         <item>
+          <spacer name="horizontalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_7">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>1200</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="grpContact">
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="title">
+         <string>İletişim Bilgileri</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>370</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QWidget" name="contactCards" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_3"/>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>369</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="grpLicense">
+        <property name="title">
+         <string>Lisans Bilgileri</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QWidget" name="innerLicense" native="true">
+           <layout class="QFormLayout" name="formLayout">
+            <property name="horizontalSpacing">
+             <number>15</number>
+            </property>
+            <property name="verticalSpacing">
+             <number>15</number>
+            </property>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Lisans Durumu: </string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QWidget" name="widget" native="true">
+              <layout class="QHBoxLayout" name="horizontalLayout_5">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="imgLicenseStatus">
+                 <property name="minimumSize">
+                  <size>
+                   <width>22</width>
+                   <height>22</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>22</width>
+                   <height>22</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string/>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="lblLicenseStatus">
+                 <property name="text">
+                  <string>Etkinleştirildi</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="lblSerial">
+              <property name="text">
+               <string>Lisans Anahtarı:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="txtSerial">
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>
        </widget>
       </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
      </layout>
     </widget>
    </item>
    <item>
-    <spacer name="verticalSpacer">
+    <spacer name="horizontalSpacer_6">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>40</width>
+       <height>20</height>
       </size>
      </property>
     </spacer>

--- a/src/UI/DatabasePage/databasepage.cpp
+++ b/src/UI/DatabasePage/databasepage.cpp
@@ -251,7 +251,7 @@ namespace UI {
         });
     }
 
-    void ikoOSKAR::UI::DatabasePage::createStudentContextMenu(const QPoint& p)
+    void ikoOSKAR::UI::DatabasePage::createStudentContextMenu()
     {
         QMenu menuStudent;
 
@@ -265,7 +265,7 @@ namespace UI {
         connect(&del, &QAction::triggered, this, &DatabasePage::on_btnDelete_clicked);
         menuStudent.addAction(&del);
 
-        menuStudent.exec(mapToGlobal(p));
+        menuStudent.exec(QCursor::pos());
     }
 
     QString DatabasePage::currentClassname()

--- a/src/UI/DatabasePage/databasepage.h
+++ b/src/UI/DatabasePage/databasepage.h
@@ -46,7 +46,7 @@ namespace UI {
         void refresh();
         void createButtonMenus();
         void createTabWidget();
-        void createStudentContextMenu(const QPoint& p);
+        void createStudentContextMenu();
         inline QString currentClassname();
         Ui::DatabasePage* ui;
         ikoOSKAR::BLL::DatabaseHelper* bll;

--- a/src/UI/DatabasePage/databasepage.ui
+++ b/src/UI/DatabasePage/databasepage.ui
@@ -181,7 +181,7 @@
           <widget class="QPushButton" name="btnEdit">
            <property name="minimumSize">
             <size>
-             <width>220</width>
+             <width>225</width>
              <height>40</height>
             </size>
            </property>

--- a/src/UI/DatabasePage/databasepage.ui
+++ b/src/UI/DatabasePage/databasepage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1210</width>
+    <width>1191</width>
     <height>583</height>
    </rect>
   </property>
@@ -19,67 +19,53 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout_3">
    <property name="leftMargin">
-    <number>0</number>
+    <number>11</number>
    </property>
    <property name="topMargin">
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>11</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>11</number>
    </property>
    <item>
-    <widget class="QFrame" name="frmContent">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+    <spacer name="horizontalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
      </property>
-     <property name="lineWidth">
-      <number>0</number>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QTabWidget" name="tabWidget"/>
-      </item>
-     </layout>
-    </widget>
+    </spacer>
    </item>
    <item>
-    <widget class="QFrame" name="frmButtons">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+    <widget class="QWidget" name="wdCenter" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+     <property name="minimumSize">
+      <size>
+       <width>600</width>
+       <height>0</height>
+      </size>
      </property>
-     <property name="lineWidth">
-      <number>0</number>
+     <property name="maximumSize">
+      <size>
+       <width>1000</width>
+       <height>16777215</height>
+      </size>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="spacing">
-       <number>7</number>
-      </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -93,136 +79,222 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QPushButton" name="btnAdd">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>40</height>
-         </size>
+       <widget class="QFrame" name="frmContent">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
-         </size>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
-        <property name="text">
-         <string>Öğrenci Ekle  </string>
+        <property name="lineWidth">
+         <number>0</number>
         </property>
-        <property name="icon">
-         <iconset resource="../../../assets/resources.qrc">
-          <normaloff>:/add.png</normaloff>:/add.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>22</width>
-          <height>22</height>
-         </size>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QTabWidget" name="tabWidget"/>
+         </item>
+        </layout>
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="btnEdit">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Öğrenci Bilgilerini Düzenle</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../assets/resources.qrc">
-          <normaloff>:/edit.png</normaloff>:/edit.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>22</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnDelete">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Öğrenci Sil</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../../assets/resources.qrc">
-          <normaloff>:/remove.png</normaloff>:/remove.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>22</width>
-          <height>22</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer">
+       <spacer name="horizontalSpacer_5">
         <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+         <enum>Qt::Orientation::Horizontal</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>68</width>
-          <height>20</height>
+          <width>1200</width>
+          <height>0</height>
          </size>
         </property>
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="btnMore">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>40</height>
-         </size>
+       <widget class="QFrame" name="frmButtons">
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>40</height>
-         </size>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
-        <property name="text">
-         <string>Diğer Komutlar  </string>
+        <property name="lineWidth">
+         <number>0</number>
         </property>
-        <property name="icon">
-         <iconset resource="../../../assets/resources.qrc">
-          <normaloff>:/more.png</normaloff>:/more.png</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>22</width>
-          <height>22</height>
-         </size>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="btnAdd">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Öğrenci Ekle  </string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../assets/resources.qrc">
+             <normaloff>:/add.png</normaloff>:/add.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnEdit">
+           <property name="minimumSize">
+            <size>
+             <width>220</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Öğrenci Bilgilerini Düzenle</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../assets/resources.qrc">
+             <normaloff>:/edit.png</normaloff>:/edit.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnDelete">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Öğrenci Sil</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../assets/resources.qrc">
+             <normaloff>:/remove.png</normaloff>:/remove.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>1000</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnMore">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Diğer Komutlar  </string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../assets/resources.qrc">
+             <normaloff>:/more.png</normaloff>:/more.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>22</width>
+             <height>22</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/UI/MainWindow/mainwindow.ui
+++ b/src/UI/MainWindow/mainwindow.ui
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../../assets/resources.qrc">
     <normaloff>:/Icon-WhiteBGx128.png</normaloff>:/Icon-WhiteBGx128.png</iconset>
   </property>
   <widget class="QWidget" name="centralwidget">
@@ -26,19 +26,19 @@
      <number>3</number>
     </property>
     <property name="sizeConstraint">
-     <enum>QLayout::SetMaximumSize</enum>
+     <enum>QLayout::SizeConstraint::SetMaximumSize</enum>
     </property>
     <property name="leftMargin">
-     <number>11</number>
+     <number>0</number>
     </property>
     <property name="topMargin">
-     <number>3</number>
+     <number>0</number>
     </property>
     <property name="rightMargin">
-     <number>11</number>
+     <number>0</number>
     </property>
     <property name="bottomMargin">
-     <number>11</number>
+     <number>0</number>
     </property>
     <item>
      <widget class="QFrame" name="frameHeaderbar">
@@ -51,36 +51,39 @@
       <property name="minimumSize">
        <size>
         <width>0</width>
-        <height>70</height>
+        <height>77</height>
        </size>
       </property>
       <property name="maximumSize">
        <size>
         <width>16777215</width>
-        <height>75</height>
+        <height>77</height>
        </size>
       </property>
       <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+       <enum>QFrame::Shape::NoFrame</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Plain</enum>
+       <enum>QFrame::Shadow::Plain</enum>
       </property>
       <property name="lineWidth">
        <number>0</number>
       </property>
       <layout class="QHBoxLayout" name="headerbarHLayout">
+       <property name="spacing">
+        <number>11</number>
+       </property>
        <property name="leftMargin">
-        <number>0</number>
+        <number>11</number>
        </property>
        <property name="topMargin">
-        <number>0</number>
+        <number>11</number>
        </property>
        <property name="rightMargin">
-        <number>0</number>
+        <number>11</number>
        </property>
        <property name="bottomMargin">
-        <number>0</number>
+        <number>11</number>
        </property>
        <item>
         <widget class="QPushButton" name="btnCurrentPage">
@@ -95,13 +98,13 @@
          </property>
          <property name="minimumSize">
           <size>
-           <width>60</width>
-           <height>60</height>
+           <width>48</width>
+           <height>48</height>
           </size>
          </property>
          <property name="maximumSize">
           <size>
-           <width>60</width>
+           <width>48</width>
            <height>60</height>
           </size>
          </property>
@@ -109,7 +112,7 @@
           <string/>
          </property>
          <property name="icon">
-          <iconset>
+          <iconset resource="../../../assets/resources.qrc">
            <normaloff>:/home.png</normaloff>:/home.png</iconset>
          </property>
          <property name="iconSize">
@@ -143,12 +146,12 @@
          <item>
           <spacer name="verticalSpacer">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
              <width>20</width>
-             <height>6</height>
+             <height>4</height>
             </size>
            </property>
           </spacer>
@@ -185,7 +188,7 @@
             <string>&lt;page name&gt; asdsadasddasd</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+            <set>Qt::AlignmentFlag::AlignBottom|Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft</set>
            </property>
           </widget>
          </item>
@@ -216,14 +219,14 @@
             <string>&lt;description&gt;</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
            </property>
           </widget>
          </item>
          <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -238,7 +241,7 @@
        <item>
         <spacer name="horizontalSpacer">
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -250,6 +253,9 @@
        </item>
        <item>
         <layout class="QHBoxLayout" name="navbarHLayout">
+         <property name="spacing">
+          <number>6</number>
+         </property>
          <item>
           <widget class="QPushButton" name="btnHome">
            <property name="enabled">
@@ -280,7 +286,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="../../../assets/resources.qrc">
              <normaloff>:/home.png</normaloff>:/home.png</iconset>
            </property>
            <property name="iconSize">
@@ -324,7 +330,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="../../../assets/resources.qrc">
              <normaloff>:/students.png</normaloff>:/students.png</iconset>
            </property>
            <property name="iconSize">
@@ -362,7 +368,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="../../../assets/resources.qrc">
              <normaloff>:/scheme.png</normaloff>:/scheme.png</iconset>
            </property>
            <property name="iconSize">
@@ -400,7 +406,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset>
+            <iconset resource="../../../assets/resources.qrc">
              <normaloff>:/help.png</normaloff>:/help.png</iconset>
            </property>
            <property name="iconSize">
@@ -419,15 +425,15 @@
     <item>
      <widget class="QFrame" name="frameContent">
       <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
+       <enum>QFrame::Shape::NoFrame</enum>
       </property>
       <property name="frameShadow">
-       <enum>QFrame::Plain</enum>
+       <enum>QFrame::Shadow::Plain</enum>
       </property>
       <property name="lineWidth">
        <number>0</number>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
+      <layout class="QHBoxLayout" name="horizontalLayout">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -442,6 +448,12 @@
        </property>
        <item>
         <widget class="QStackedWidget" name="stackedWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="lineWidth">
           <number>0</number>
          </property>
@@ -453,6 +465,8 @@
    </layout>
   </widget>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../assets/resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/UI/MultiImportDialog/miclasspickerui.cpp
+++ b/src/UI/MultiImportDialog/miclasspickerui.cpp
@@ -23,7 +23,7 @@ namespace UI {
 
     void MIClassPickerUi::on_btnNext_clicked()
     {
-        emit selectedGradeAndSection(ui->spnGrade->value(), ui->cmbSection->currentText());
+        emit selectedGradeAndSection(ui->cmbGrade->currentIndex() + 9, ui->cmbSection->currentText());
     }
 
 } // namespace UI

--- a/src/UI/MultiImportDialog/miclasspickerui.ui
+++ b/src/UI/MultiImportDialog/miclasspickerui.ui
@@ -107,14 +107,34 @@
        <number>15</number>
       </property>
       <item row="0" column="1">
-       <widget class="QSpinBox" name="spnGrade">
-        <property name="minimum">
-         <number>9</number>
-        </property>
-        <property name="maximum">
-         <number>12</number>
-        </property>
-       </widget>
+        <widget class="QComboBox" name="cmbGrade">
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <property name="maxVisibleItems">
+           <number>9</number>
+          </property>
+          <item>
+           <property name="text">
+            <string>9</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>10</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>11</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>12</string>
+          </property>
+          </item>
+         </widget>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="lblSection">

--- a/src/UI/SchemesPage/examwidget.cpp
+++ b/src/UI/SchemesPage/examwidget.cpp
@@ -109,7 +109,7 @@ namespace UI {
 
         if (expanded) {
             setFrameStyle(QFrame::StyledPanel | QFrame::Raised);
-            btnToggle->setText("  " + exam.name + "\n  " + exam.date.toString("dd/MM/yyyy"));
+            btnToggle->setText("  " + exam.name + "\n  " + exam.date.toString("dd MMMM yyyy"));
             mainLayout->setContentsMargins(9, 5, 9, 5);
         } else {
             setFrameStyle(0);

--- a/src/UI/SchemesPage/innerexamwidget.cpp
+++ b/src/UI/SchemesPage/innerexamwidget.cpp
@@ -31,7 +31,7 @@ namespace UI {
             ui->frmLeft->layout()->setContentsMargins(0, 0, 0, 0);
             ui->frame->layout()->setContentsMargins(0, 0, 0, 0);
             layout()->setContentsMargins(0, 0, 0, 0);
-            setMaximumHeight(260);
+            setMaximumHeight(180);
         }
     }
 

--- a/src/UI/SchemesPage/innerexamwidget.ui
+++ b/src/UI/SchemesPage/innerexamwidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>820</width>
-    <height>476</height>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,19 +23,19 @@
       </size>
      </property>
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
+      <enum>QFrame::Shadow::Raised</enum>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
       <item>
        <widget class="QFrame" name="frmHeader">
         <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
@@ -55,17 +55,17 @@
             <string>Sınav Düzeni Oluşturuldu</string>
            </property>
            <property name="alignment">
-            <set>Qt::AlignCenter</set>
+            <set>Qt::AlignmentFlag::AlignCenter</set>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QFrame" name="frmSubHeader">
            <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Shadow::Raised</enum>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <property name="spacing">
@@ -86,7 +86,7 @@
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -107,7 +107,7 @@
                <string>Sınav Adı</string>
               </property>
               <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+               <set>Qt::AlignmentFlag::AlignRight|Qt::AlignmentFlag::AlignTrailing|Qt::AlignmentFlag::AlignVCenter</set>
               </property>
              </widget>
             </item>
@@ -132,7 +132,7 @@
             <item>
              <spacer name="horizontalSpacer_2">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -154,7 +154,7 @@
       <item>
        <widget class="QFrame" name="frmForm">
         <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
         <property name="lineWidth">
          <number>0</number>
@@ -163,7 +163,7 @@
          <item>
           <spacer name="horizontalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -176,10 +176,10 @@
          <item>
           <widget class="QFrame" name="frmLeft">
            <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Shadow::Raised</enum>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_4"/>
           </widget>
@@ -187,16 +187,16 @@
          <item>
           <widget class="QFrame" name="frmVSpacer">
            <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Shadow::Raised</enum>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5">
             <item>
              <spacer name="verticalSpacer">
               <property name="orientation">
-               <enum>Qt::Vertical</enum>
+               <enum>Qt::Orientation::Vertical</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -212,10 +212,10 @@
          <item>
           <widget class="QFrame" name="frmRight">
            <property name="frameShape">
-            <enum>QFrame::NoFrame</enum>
+            <enum>QFrame::Shape::NoFrame</enum>
            </property>
            <property name="frameShadow">
-            <enum>QFrame::Raised</enum>
+            <enum>QFrame::Shadow::Raised</enum>
            </property>
            <layout class="QHBoxLayout" name="horizontalLayout_5"/>
           </widget>
@@ -223,7 +223,7 @@
          <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+            <enum>Qt::Orientation::Horizontal</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>

--- a/src/UI/SchemesPage/monthheaderwidget.cpp
+++ b/src/UI/SchemesPage/monthheaderwidget.cpp
@@ -17,6 +17,7 @@ namespace UI {
 
         layout->addWidget(label);
         layout->addWidget(headerLine);
+        layout->setContentsMargins(0, 11, 0, 11);
 
         setLayout(layout);
     }

--- a/src/UI/SchemesPage/schemespage.cpp
+++ b/src/UI/SchemesPage/schemespage.cpp
@@ -60,12 +60,12 @@ namespace UI {
                 continue;
             }
 
-            auto monthHeader = new MonthHeaderWidget(month);
+            auto monthHeader = responsiveWrap(new MonthHeaderWidget(month));
             ui->historyRoot->layout()->addWidget(monthHeader);
             historyWidgets.append(monthHeader);
 
             for (const auto& exam : examList) {
-                auto examWidget = new ExamWidget(exam, 100);
+                auto examWidget = responsiveWrap(new ExamWidget(exam, 100));
                 ui->historyRoot->layout()->addWidget(examWidget);
                 historyWidgets.append(examWidget);
             }

--- a/src/UI/SchemesPage/schemespage.cpp
+++ b/src/UI/SchemesPage/schemespage.cpp
@@ -78,6 +78,21 @@ namespace UI {
         emit descriptionUpdated(*getDescription());
     }
 
+    QWidget* SchemesPage::responsiveWrap(QWidget* content)
+    {
+        content->setMaximumWidth(1000);
+        content->setMinimumWidth(600);
+
+        QWidget* wrapper = new QWidget();
+        wrapper->setContentsMargins(0, 0, 0, 0);
+
+        QHBoxLayout* layout = new QHBoxLayout(wrapper);
+        layout->setContentsMargins(0, 0, 0, 0);
+        layout->addWidget(content);
+
+        return wrapper;
+    }
+
     void SchemesPage::refreshHistory()
     {
         // Clear the history root

--- a/src/UI/SchemesPage/schemespage.h
+++ b/src/UI/SchemesPage/schemespage.h
@@ -5,6 +5,7 @@
 #include "BLL/HistoryProvider/historyprovider.h"
 #include "UI/Common/page.h"
 #include <QLayoutItem>
+#include <QScrollArea>
 #include <QWidget>
 
 namespace ikoOSKAR {
@@ -34,6 +35,7 @@ namespace UI {
         QLayoutItem* verticalSpacer;
         QLabel* lblEmptyHistory;
         BLL::Authenticator* authenticator;
+        QWidget* responsiveWrap(QWidget*);
 
         explicit SchemesPage(QWidget* parent = nullptr);
         void setupHistoryUi(const History& history);

--- a/src/UI/SchemesPage/schemespage.ui
+++ b/src/UI/SchemesPage/schemespage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>975</width>
+    <width>1061</width>
     <height>573</height>
    </rect>
   </property>
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <property name="spacing">
-    <number>3</number>
+    <number>4</number>
    </property>
    <property name="leftMargin">
     <number>0</number>
@@ -26,110 +26,174 @@
    <property name="rightMargin">
     <number>0</number>
    </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
-    <widget class="QFrame" name="frmNewScheme">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+    <widget class="QWidget" name="wdCenter" native="true">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>70</height>
+      </size>
      </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>11</number>
+      </property>
       <property name="topMargin">
        <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>25</number>
       </property>
       <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
-       <widget class="QPushButton" name="btnNewScheme">
+       <widget class="QFrame" name="frmNewScheme">
         <property name="minimumSize">
          <size>
-          <width>250</width>
-          <height>50</height>
+          <width>600</width>
+          <height>0</height>
          </size>
         </property>
         <property name="maximumSize">
          <size>
-          <width>250</width>
-          <height>50</height>
+          <width>1000</width>
+          <height>16777215</height>
          </size>
         </property>
-        <property name="text">
-         <string>  Yeni Sınav Düzeni Oluştur</string>
+        <property name="frameShape">
+         <enum>QFrame::Shape::NoFrame</enum>
         </property>
-        <property name="icon">
-         <iconset>
-          <normaloff>:/new-scheme.png</normaloff>:/new-scheme.png</iconset>
+        <property name="frameShadow">
+         <enum>QFrame::Shadow::Raised</enum>
         </property>
-        <property name="iconSize">
-         <size>
-          <width>30</width>
-          <height>30</height>
-         </size>
-        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="lblHeader">
+           <property name="text">
+            <string>Önceki Sınav Düzenleri</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Orientation::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>3000</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnNewScheme">
+           <property name="minimumSize">
+            <size>
+             <width>250</width>
+             <height>50</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>250</width>
+             <height>50</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>  Yeni Sınav Düzeni Oluştur</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../../assets/resources.qrc">
+             <normaloff>:/new-scheme.png</normaloff>:/new-scheme.png</iconset>
+           </property>
+           <property name="iconSize">
+            <size>
+             <width>30</width>
+             <height>30</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>
     </widget>
    </item>
    <item>
-    <widget class="QFrame" name="frmLine">
-     <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="topMargin">
-       <number>19</number>
-      </property>
-      <property name="bottomMargin">
-       <number>19</number>
-      </property>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLabel" name="lblHeader">
-     <property name="text">
-      <string>Önceki Sınav Düzenleri</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
+     </property>
+     <property name="lineWidth">
+      <number>0</number>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOn</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContents</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
      </property>
      <widget class="QWidget" name="historyRoot">
       <property name="geometry">
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>975</width>
-        <height>449</height>
+        <width>1047</width>
+        <height>499</height>
        </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <property name="spacing">
         <number>4</number>
        </property>
        <property name="leftMargin">
-        <number>20</number>
+        <number>11</number>
        </property>
        <property name="topMargin">
-        <number>19</number>
+        <number>0</number>
        </property>
        <property name="rightMargin">
-        <number>20</number>
+        <number>11</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
        </property>
       </layout>
      </widget>
@@ -137,6 +201,8 @@
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../assets/resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/UI/SchemesPage/xlsxbutton.cpp
+++ b/src/UI/SchemesPage/xlsxbutton.cpp
@@ -13,7 +13,6 @@ namespace UI {
     {
         ui->setupUi(this);
         ui->btnXlsxFile->setText(name);
-        ui->btnXlsxFile->setIcon(QIcon(":/xlsx.png"));
     }
 
     XlsxButton::~XlsxButton()

--- a/src/UI/SchemesPage/xlsxbutton.ui
+++ b/src/UI/SchemesPage/xlsxbutton.ui
@@ -6,20 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>250</width>
-    <height>250</height>
+    <width>170</width>
+    <height>170</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>250</width>
-    <height>250</height>
+    <width>170</width>
+    <height>170</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>250</width>
-    <height>250</height>
+    <width>170</width>
+    <height>170</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -42,14 +42,14 @@
     <widget class="QToolButton" name="btnXlsxFile">
      <property name="minimumSize">
       <size>
-       <width>250</width>
-       <height>250</height>
+       <width>170</width>
+       <height>170</height>
       </size>
      </property>
      <property name="maximumSize">
       <size>
-       <width>250</width>
-       <height>250</height>
+       <width>170</width>
+       <height>170</height>
       </size>
      </property>
      <property name="text">
@@ -61,8 +61,8 @@
      </property>
      <property name="iconSize">
       <size>
-       <width>200</width>
-       <height>200</height>
+       <width>130</width>
+       <height>130</height>
       </size>
      </property>
      <property name="toolButtonStyle">

--- a/src/UI/SchemesPage/xlsxbutton.ui
+++ b/src/UI/SchemesPage/xlsxbutton.ui
@@ -55,6 +55,10 @@
      <property name="text">
       <string>Sınıf Karma Listeleri</string>
      </property>
+     <property name="icon">
+      <iconset resource="../../../assets/resources.qrc">
+       <normaloff>:/xlsx.png</normaloff>:/xlsx.png</iconset>
+     </property>
      <property name="iconSize">
       <size>
        <width>200</width>
@@ -62,12 +66,14 @@
       </size>
      </property>
      <property name="toolButtonStyle">
-      <enum>Qt::ToolButtonTextUnderIcon</enum>
+      <enum>Qt::ToolButtonStyle::ToolButtonTextUnderIcon</enum>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../assets/resources.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/UI/StudentEditorDialog/studenteditordialog.cpp
+++ b/src/UI/StudentEditorDialog/studenteditordialog.cpp
@@ -18,7 +18,7 @@ namespace UI {
         case ADD:
             ui->lblHeader->setText("Yeni Öğrenci Ekle");
             setWindowTitle("Yeni Öğrenci Ekle");
-            ui->spnGrade->setValue(student->grade);
+            ui->cmbGrade->setCurrentIndex(student->grade - 9);
             ui->cmbSection->setCurrentIndex((int)student->section[0].unicode() - 65);
             break;
         case EDIT:
@@ -27,7 +27,7 @@ namespace UI {
             ui->spnId->setValue(student->id);
             ui->lnFirstName->setText(student->firstName);
             ui->lnLastName->setText(student->lastName);
-            ui->spnGrade->setValue(student->grade);
+            ui->cmbGrade->setCurrentIndex(student->grade - 9);
             ui->cmbSection->setCurrentIndex((int)student->section[0].unicode() - 65);
             break;
         }
@@ -59,7 +59,7 @@ namespace UI {
         int id = ui->spnId->value();
         QString firstName = ui->lnFirstName->text();
         QString lastName = ui->lnLastName->text();
-        int grade = ui->spnGrade->value();
+        int grade = ui->cmbGrade->currentIndex() + 9;
         QString section = ui->cmbSection->currentText();
 
         bool success = false;

--- a/src/UI/StudentEditorDialog/studenteditordialog.ui
+++ b/src/UI/StudentEditorDialog/studenteditordialog.ui
@@ -30,14 +30,14 @@
       <string>Öğrenci [Ekle|Bilgilerini Düzenle]</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignCenter</set>
+      <set>Qt::AlignmentFlag::AlignCenter</set>
      </property>
     </widget>
    </item>
    <item>
     <widget class="QFrame" name="frame">
      <property name="frameShape">
-      <enum>QFrame::NoFrame</enum>
+      <enum>QFrame::Shape::NoFrame</enum>
      </property>
      <property name="lineWidth">
       <number>0</number>
@@ -84,13 +84,33 @@
        </widget>
       </item>
       <item row="3" column="1">
-       <widget class="QSpinBox" name="spnGrade">
-        <property name="minimum">
+       <widget class="QComboBox" name="cmbGrade">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <property name="maxVisibleItems">
          <number>9</number>
         </property>
-        <property name="maximum">
-         <number>12</number>
+        <item>
+         <property name="text">
+          <string>9</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>10</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>11</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>12</string>
         </property>
+        </item>
        </widget>
       </item>
       <item row="4" column="0">
@@ -259,10 +279,10 @@
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Save</set>
      </property>
     </widget>
    </item>

--- a/src/UI/WelcomePage/welcomepage.ui
+++ b/src/UI/WelcomePage/welcomepage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1005</width>
+    <width>1268</width>
     <height>511</height>
    </rect>
   </property>
@@ -18,19 +18,44 @@
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
-    <number>0</number>
+    <number>11</number>
    </property>
    <property name="topMargin">
     <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>0</number>
+    <number>11</number>
    </property>
    <property name="bottomMargin">
-    <number>0</number>
+    <number>11</number>
    </property>
    <item>
+    <spacer name="horizontalSpacer_5">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <widget class="QFrame" name="frmV">
+     <property name="minimumSize">
+      <size>
+       <width>600</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>1000</width>
+       <height>16777215</height>
+      </size>
+     </property>
      <property name="frameShape">
       <enum>QFrame::Shape::NoFrame</enum>
      </property>
@@ -50,55 +75,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item>
-       <widget class="QFrame" name="frmTop">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::Shape::NoFrame</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Shadow::Raised</enum>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <spacer name="verticalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Orientation::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>27</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </widget>
-      </item>
       <item>
        <widget class="QFrame" name="frmRoot">
         <property name="frameShape">
@@ -123,19 +99,6 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
          <item>
           <widget class="QLabel" name="lblText">
            <property name="font">
@@ -168,17 +131,35 @@
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer_2">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
+          <widget class="QWidget" name="widget" native="true">
+           <property name="minimumSize">
             <size>
-             <width>40</width>
-             <height>20</height>
+             <width>10</width>
+             <height>0</height>
             </size>
            </property>
-          </spacer>
+           <property name="maximumSize">
+            <size>
+             <width>80</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>300</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
          </item>
          <item>
           <widget class="QFrame" name="frmIcon">
@@ -231,7 +212,7 @@
                <string/>
               </property>
               <property name="icon">
-               <iconset>
+               <iconset resource="../../../assets/resources.qrc">
                 <normaloff>:/Icon-Transparent.png</normaloff>
                 <disabledoff>:/Icon-Transparent.png</disabledoff>
                 <disabledon>:/Icon-Transparent.png</disabledon>:/Icon-Transparent.png</iconset>
@@ -266,21 +247,21 @@
            </layout>
           </widget>
          </item>
-         <item>
-          <spacer name="horizontalSpacer_3">
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
         </layout>
        </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Orientation::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>1200</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <spacer name="verticalSpacer_3">
@@ -298,8 +279,23 @@
      </layout>
     </widget>
    </item>
+   <item>
+    <spacer name="horizontalSpacer_4">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
- <resources/>
+ <resources>
+  <include location="../../../assets/resources.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
- Set a minimum and maximum content width of 600 and 1000pt. If the window is bigger than 1000pt, the content gets horizontally centered with two blank bars on both sides.
- Set the default margin size to 11px.
- Fix content menu popup location on `DatabasePage`.
- Shrunk the size of `XlsxButton` to save some space.
- Move the header to the left and the create button to the right, both on the same row, on `SchemesPage`.
- Replace all `QSpinBox`es with `QComboBox`es.
- Display full month name when not collapsed on `ExamWidget`.